### PR TITLE
feat : 버튼 컴포넌트

### DIFF
--- a/packages/client/src/Atoms/Button/index.tsx
+++ b/packages/client/src/Atoms/Button/index.tsx
@@ -1,0 +1,35 @@
+import React, { CSSProperties } from 'react'
+import { theme } from '../../styles/index'
+import styled from '@emotion/styled'
+
+interface Props {
+  disabled?: boolean
+  style?: CSSProperties
+  onClick?(event: React.MouseEvent<HTMLButtonElement>): void
+  children?: React.ReactNode
+}
+
+const Button: React.FC<Props> = ({
+  disabled = false,
+  style,
+  onClick,
+  children,
+}) => {
+  return (
+    <>
+      <EButton disabled={disabled} onClick={onClick} style={{ ...style }}>
+        {children}
+      </EButton>
+    </>
+  )
+}
+
+const EButton = styled.button`
+  cursor: pointer;
+  background-color: ${theme.PRIMARY1};
+  width: 233px;
+  height: 164px;
+  border-radius: 20px;
+`
+
+export default Button

--- a/packages/client/src/Atoms/Button/index.tsx
+++ b/packages/client/src/Atoms/Button/index.tsx
@@ -2,14 +2,14 @@ import React, { CSSProperties } from 'react'
 import { theme } from '../../styles/index'
 import styled from '@emotion/styled'
 
-interface Props {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   disabled?: boolean
   style?: CSSProperties
   onClick?(event: React.MouseEvent<HTMLButtonElement>): void
   children?: React.ReactNode
 }
 
-const Button: React.FC<Props> = ({
+const Button: React.FC<ButtonProps> = ({
   disabled = false,
   style,
   onClick,


### PR DESCRIPTION
# 💬 세부사항

Atoms 버튼 컴포넌트

## 📎 관련 이슈

close #9 

## 🖼 스크린샷

왼쪽이 style props로 전달하여 생성한 버튼 컴포넌트
오른쪽이 기본 defalut 버튼 컴포넌트 (명세서에서 가장 많이 사용되는 크기, 색상 기준으로 작성)

![스크린샷 2022-08-04 오후 8 22 26](https://user-images.githubusercontent.com/52727782/182835221-bdabfa6c-c4a4-40a7-8bbd-5713ee68543d.png)

## ⏰ 실제 소요 시간

20분