### PR TITLE
Feat/20/atoms modal

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,18 +3,15 @@ import { ThemeProvider } from '@emotion/react'
 import { theme } from './styles'
 import GlobalStyle from './styles/GlobalStyles'
 import { getAllInfo } from './apis/kiosk'
-import { TCategory, TMenu } from 'types'
-import Modal from 'atoms/Modal'
+import { TCategory } from 'types'
 import Header from './components/Header'
 import Page from 'components/Page'
+import styled from '@emotion/styled'
 
 const App = () => {
   // 데이터 필드 변경에 따른 ts타입 나중에 변경 예정
   const [kioskData, setKioskData] = useState<TCategory[]>()
   const [selected, setSelected] = useState<number>(1)
-  const [selectedMenuId, setSelectedMenuId] = useState<number | undefined>()
-  const [selectedMenu, setSelectedMenu] = useState<TMenu>()
-  const [visible, setVisible] = useState(false)
 
   const getData = async () => {
     const data = await getAllInfo()
@@ -29,27 +26,9 @@ const App = () => {
     [],
   )
 
-  const onClickMenu = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const { id } = (e.currentTarget as HTMLElement).dataset
-      setSelectedMenuId(Number(id))
-      const menu = kioskData?.[selected - 1]?.menus.find(
-        (item) => item.id === Number(id),
-      )
-      setSelectedMenu(menu)
-      setVisible(true)
-    },
-    [kioskData, selected],
-  )
-
   useEffect(() => {
     getData()
   }, [])
-
-  // useEffect(() => {
-  //   return
-  //   /setSelectedMenu
-  // }, [selectedMenuId])
 
   return (
     <ThemeProvider theme={theme}>
@@ -60,16 +39,19 @@ const App = () => {
           selected={selected}
           onClickCategory={onClickCategory}></Header>
 
-        <Page
-          menus={kioskData?.[selected - 1].menus}
-          onClickMenu={onClickMenu}></Page>
+        {kioskData ? (
+          <Page menus={kioskData?.[selected - 1].menus}></Page>
+        ) : null}
       </div>
-      <Modal visible={visible} onClose={() => setVisible(false)}>
-        <div></div>
-        {/* <button onClick={() => setVisible(false)}>Close</button> */}
-      </Modal>
     </ThemeProvider>
   )
 }
+
+const MenuModalWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 500px;
+  height: 500px;
+`
 
 export default App

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,16 +3,18 @@ import { ThemeProvider } from '@emotion/react'
 import { theme } from './styles'
 import GlobalStyle from './styles/GlobalStyles'
 import { getAllInfo } from './apis/kiosk'
-import Tab from 'atoms/Tab'
-import styled from '@emotion/styled'
-import TabItem from 'atoms/Tab/TabItem'
-import { TCategory } from 'types'
+import { TCategory, TMenu } from 'types'
+import Modal from 'atoms/Modal'
+import Header from './components/Header'
+import Page from 'components/Page'
 
 const App = () => {
   // 데이터 필드 변경에 따른 ts타입 나중에 변경 예정
   const [kioskData, setKioskData] = useState<TCategory[]>()
   const [selected, setSelected] = useState<number>(1)
   const [selectedMenuId, setSelectedMenuId] = useState<number | undefined>()
+  const [selectedMenu, setSelectedMenu] = useState<TMenu>()
+  const [visible, setVisible] = useState(false)
 
   const getData = async () => {
     const data = await getAllInfo()
@@ -27,62 +29,47 @@ const App = () => {
     [],
   )
 
-  const onClickMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const { id } = (e.target as HTMLElement).dataset
-    setSelectedMenuId(Number(id))
-  }, [])
+  const onClickMenu = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const { id } = (e.currentTarget as HTMLElement).dataset
+      setSelectedMenuId(Number(id))
+      const menu = kioskData?.[selected - 1]?.menus.find(
+        (item) => item.id === Number(id),
+      )
+      setSelectedMenu(menu)
+      setVisible(true)
+    },
+    [kioskData, selected],
+  )
 
   useEffect(() => {
     getData()
   }, [])
 
+  // useEffect(() => {
+  //   return
+  //   /setSelectedMenu
+  // }, [selectedMenuId])
+
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <div className="App">
-        <TabWrapper>
-          {kioskData ? (
-            kioskData.length ? (
-              kioskData.map(({ id, name }) => (
-                <Tab
-                  key={id}
-                  id={id}
-                  category={name}
-                  active={selected === id}
-                  onClickCategory={onClickCategory}
-                />
-              ))
-            ) : (
-              <div>데이터가 없습니다.</div>
-            )
-          ) : (
-            <div>로딩중</div>
-          )}
-        </TabWrapper>
+        <Header
+          categories={kioskData}
+          selected={selected}
+          onClickCategory={onClickCategory}></Header>
 
-        <TabItemWrapper>
-          {kioskData?.[selected - 1]?.menus?.map((menu, index) => (
-            <TabItem
-              key={menu.id}
-              menu={menu}
-              onClickMenu={onClickMenu}
-              rank={index}></TabItem>
-          ))}
-        </TabItemWrapper>
+        <Page
+          menus={kioskData?.[selected - 1].menus}
+          onClickMenu={onClickMenu}></Page>
       </div>
+      <Modal visible={visible} onClose={() => setVisible(false)}>
+        <div></div>
+        {/* <button onClick={() => setVisible(false)}>Close</button> */}
+      </Modal>
     </ThemeProvider>
   )
 }
 
-const TabWrapper = styled.div`
-  margin-top: 30px;
-  display: flex;
-  justify-items: center;
-  justify-content: space-around;
-`
-const TabItemWrapper = styled.div`
-  display: flex;
-  justify-items: flex-start;
-  flex-wrap: wrap;
-`
 export default App

--- a/packages/client/src/Atoms/Modal/index.tsx
+++ b/packages/client/src/Atoms/Modal/index.tsx
@@ -35,8 +35,8 @@ interface Props {
 
 const Modal: React.FC<Props> = ({
   children,
-  width = 500,
-  height = 300,
+  width = 900,
+  height = 800,
   visible = false,
   onClose,
   style,

--- a/packages/client/src/Atoms/Modal/index.tsx
+++ b/packages/client/src/Atoms/Modal/index.tsx
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled'
+import { CSSProperties, useEffect, useMemo } from 'react'
+import ReactDOM from 'react-dom'
+import useClickAway from '../../hooks/useClickAway'
+
+const BackgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 8px;
+  background-color: white;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+`
+
+interface Props {
+  children: React.ReactNode
+  width?: number
+  height?: number
+  style?: CSSProperties
+  visible: boolean
+  onClose(): void
+}
+
+const Modal: React.FC<Props> = ({
+  children,
+  width = 500,
+  height = 300,
+  visible = false,
+  onClose,
+  style,
+  ...props
+}) => {
+  const ref = useClickAway(() => {
+    onClose && onClose()
+  })
+
+  const containerStyle = useMemo(
+    () => ({
+      width,
+      height,
+    }),
+    [width, height],
+  )
+
+  const el = useMemo(() => document.createElement('div'), [])
+  useEffect(() => {
+    document.body.appendChild(el)
+
+    return () => {
+      document.body.removeChild(el)
+    }
+  })
+
+  return ReactDOM.createPortal(
+    <BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
+      <ModalContainer
+        ref={ref}
+        {...props}
+        style={{ ...style, ...containerStyle }}>
+        {children}
+      </ModalContainer>
+    </BackgroundDim>,
+    el,
+  )
+}
+
+export default Modal

--- a/packages/client/src/Atoms/Modal/index.tsx
+++ b/packages/client/src/Atoms/Modal/index.tsx
@@ -3,27 +3,6 @@ import { CSSProperties, useEffect, useMemo } from 'react'
 import ReactDOM from 'react-dom'
 import useClickAway from '../../hooks/useClickAway'
 
-const BackgroundDim = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 1000;
-`
-
-const ModalContainer = styled.div`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 8px;
-  background-color: white;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
-  box-sizing: border-box;
-`
-
 interface Props {
   children: React.ReactNode
   width?: number
@@ -76,4 +55,24 @@ const Modal: React.FC<Props> = ({
   )
 }
 
+const BackgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 8px;
+  background-color: white;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+`
 export default Modal

--- a/packages/client/src/Atoms/Spinner/index.tsx
+++ b/packages/client/src/Atoms/Spinner/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   loading?: boolean
 }
 
-const Spinner: React.FC<Props> = ({ size = 48, loading = true, ...props }) => {
+const Spinner: React.FC<Props> = ({ size = 128, loading = true, ...props }) => {
   const sizeStyle = {
     width: size,
     height: size,

--- a/packages/client/src/Atoms/Tab/TabItem.tsx
+++ b/packages/client/src/Atoms/Tab/TabItem.tsx
@@ -1,6 +1,6 @@
 import { css, jsx } from '@emotion/react'
 import styled from '@emotion/styled'
-import React from 'react'
+import React, { useState } from 'react'
 import { TMenu } from 'types'
 
 interface TProps {
@@ -10,18 +10,19 @@ interface TProps {
 }
 
 const TabItem: React.FC<TProps> = ({ menu, onClickMenu, rank }) => {
+  const [visible, setVisible] = useState(false)
+
   const { id, imgUrl1, imgUrl2, name, price } = menu
 
   return (
-    <TabItemWrapper data-id={id} onClick={onClickMenu}>
-      <RankSpan>{rank + 1}위</RankSpan>
-      <ImgWrapper>
-        <Img className={imgUrl2 ? 'first' : ''} src={imgUrl1} />
-        <Img src={imgUrl2} />
-      </ImgWrapper>
-      <Span>{name}</Span>
-      <Span>{price}</Span>
-    </TabItemWrapper>
+    <>
+      <TabItemWrapper data-id={id} onClick={onClickMenu}>
+        <RankSpan>{rank + 1}위</RankSpan>
+        <Img src={imgUrl1} imgUrl2={imgUrl2}></Img>
+        <Span>{name}</Span>
+        <Span>{price.toLocaleString()}원</Span>
+      </TabItemWrapper>
+    </>
   )
 }
 
@@ -51,23 +52,11 @@ const TabItemWrapper = styled.div`
   position: relative;
 `
 
-const ImgWrapper = styled.div`
+const Img = styled.img<{ imgUrl2: string }>`
   width: 300px;
   height: 300px;
-  position: relative;
   &:hover {
-    & .first {
-      display: none;
-    }
-  }
-`
-
-const Img = styled.img`
-  position: absolute;
-  top: 0;
-  left: 0;
-  &.first {
-    z-index: 1;
+    content: ${({ imgUrl2 }) => `url(${imgUrl2})`};
   }
 `
 

--- a/packages/client/src/Atoms/Tab/index.tsx
+++ b/packages/client/src/Atoms/Tab/index.tsx
@@ -23,6 +23,7 @@ const Tab: React.FC<TabWrapperProps> = ({
     <>
       <TabWrapper active={active}>
         <Button
+          data-id={id}
           style={{ backgroundColor: 'white', height: '80px' }}
           onClick={onClickCategory}
           {...props}>

--- a/packages/client/src/components/Header/index.tsx
+++ b/packages/client/src/components/Header/index.tsx
@@ -1,0 +1,44 @@
+import { TCategory } from '../../types'
+import Tab from '../../atoms/Tab'
+import styled from '@emotion/styled'
+import Spinner from '../../atoms/Spinner'
+
+interface Props {
+  categories?: TCategory[]
+  selected: number
+  onClickCategory(event: React.MouseEvent<HTMLButtonElement>): void
+}
+
+const Header: React.FC<Props> = ({ categories, onClickCategory, selected }) => {
+  return (
+    <>
+      <TabWrapper>
+        {categories ? (
+          categories.length ? (
+            categories.map(({ id, name }) => (
+              <Tab
+                key={id}
+                id={id}
+                category={name}
+                active={selected === id}
+                onClickCategory={onClickCategory}
+              />
+            ))
+          ) : (
+            <div>데이터가 없습니다.</div>
+          )
+        ) : (
+          <Spinner />
+        )}
+      </TabWrapper>
+    </>
+  )
+}
+
+const TabWrapper = styled.div`
+  margin-top: 30px;
+  display: flex;
+  justify-items: center;
+  justify-content: space-around;
+`
+export default Header

--- a/packages/client/src/components/Header/index.tsx
+++ b/packages/client/src/components/Header/index.tsx
@@ -10,25 +10,29 @@ interface Props {
 }
 
 const Header: React.FC<Props> = ({ categories, onClickCategory, selected }) => {
+  if (!categories) {
+    return (
+      <TabWrapper>
+        <Spinner />
+      </TabWrapper>
+    )
+  }
+
   return (
     <>
       <TabWrapper>
-        {categories ? (
-          categories.length ? (
-            categories.map(({ id, name }) => (
-              <Tab
-                key={id}
-                id={id}
-                category={name}
-                active={selected === id}
-                onClickCategory={onClickCategory}
-              />
-            ))
-          ) : (
-            <div>데이터가 없습니다.</div>
-          )
+        {categories.length ? (
+          categories.map(({ id, name }) => (
+            <Tab
+              key={id}
+              id={id}
+              category={name}
+              active={selected === id}
+              onClickCategory={onClickCategory}
+            />
+          ))
         ) : (
-          <Spinner />
+          <h1>데이터가 없습니다.</h1>
         )}
       </TabWrapper>
     </>

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -1,13 +1,26 @@
 import { TMenu } from 'types'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import TabItem from '../../atoms/Tab/TabItem'
 import styled from '@emotion/styled'
+import Modal from 'atoms/Modal'
+import MenuOption from 'components/MenuOption'
 interface Props {
-  menus?: TMenu[]
-  onClickMenu(event: React.MouseEvent<HTMLDivElement>): void
+  menus: TMenu[]
 }
 
-const Page: React.FC<Props> = ({ menus, onClickMenu }) => {
+const Page: React.FC<Props> = ({ menus }) => {
+  const [selectedMenuId, setSelectedMenuId] = useState<number>()
+  const [selectedMenu, setSelectedMenu] = useState<TMenu>()
+  const [visible, setVisible] = useState(false)
+
+  const onClickMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const { id } = (e.currentTarget as HTMLElement).dataset
+    setSelectedMenuId(Number(id))
+    const menu = menus.find((item) => item.id === Number(id))
+    setSelectedMenu(menu)
+    setVisible(true)
+  }, [])
+
   return (
     <>
       <TabItemWrapper>
@@ -19,9 +32,31 @@ const Page: React.FC<Props> = ({ menus, onClickMenu }) => {
             rank={index}></TabItem>
         ))}
       </TabItemWrapper>
+
+      <Modal visible={visible} onClose={() => setVisible(false)}>
+        <MenuModalWrapper>
+          {selectedMenu ? (
+            <>
+              <TabItem
+                key={selectedMenu.id}
+                menu={selectedMenu}
+                onClickMenu={onClickMenu}
+              />
+
+              <MenuOption options={selectedMenu.options} />
+            </>
+          ) : null}
+        </MenuModalWrapper>
+        {/* <button onClick={() => setVisible(false)}>Close</button> */}
+      </Modal>
     </>
   )
 }
+
+const MenuModalWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`
 
 const TabItemWrapper = styled.div`
   display: flex;

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -1,0 +1,32 @@
+import { TMenu } from 'types'
+import React from 'react'
+import TabItem from '../../atoms/Tab/TabItem'
+import styled from '@emotion/styled'
+interface Props {
+  menus?: TMenu[]
+  onClickMenu(event: React.MouseEvent<HTMLDivElement>): void
+}
+
+const Page: React.FC<Props> = ({ menus, onClickMenu }) => {
+  return (
+    <>
+      <TabItemWrapper>
+        {menus?.map((menu, index) => (
+          <TabItem
+            key={menu.id}
+            menu={menu}
+            onClickMenu={onClickMenu}
+            rank={index}></TabItem>
+        ))}
+      </TabItemWrapper>
+    </>
+  )
+}
+
+const TabItemWrapper = styled.div`
+  display: flex;
+  justify-items: flex-start;
+  flex-wrap: wrap;
+`
+
+export default Page

--- a/packages/client/src/hooks/useClickAway.tsx
+++ b/packages/client/src/hooks/useClickAway.tsx
@@ -14,7 +14,7 @@ const useClickAway = (handler: () => void) => {
     document.addEventListener('mousedown', handleEvent)
 
     return () => document.removeEventListener('mousedown', handleEvent)
-  })
+  }, [])
 
   return ref
 }

--- a/packages/client/src/hooks/useClickAway.tsx
+++ b/packages/client/src/hooks/useClickAway.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useRef } from 'react'
+
+const useClickAway = (handler: () => void) => {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const handleEvent = (e: MouseEvent) => {
+      !element.contains(e.target as HTMLDivElement) && handler()
+    }
+
+    document.addEventListener('mousedown', handleEvent)
+
+    return () => document.removeEventListener('mousedown', handleEvent)
+  })
+
+  return ref
+}
+
+export default useClickAway


### PR DESCRIPTION
# 💬 세부사항

모달 컴포넌트를 위한 clickAway hook, modal 컴포넌트 개발

## 📎 관련 이슈

close #20 

## 😭 어려웠던 점 or 참고 사항

모달 컴포넌트에서 클릭 이벤트에 따라 상태 기반으로 모달을 켰다 꼈다하는 hook을 이용합니다.
해당 hook에서 useRef를 이용해서 이벤트가 필요한 특정 dom을 지정하게 됩니다. 이때 해당 컴포넌트가 리액트로 생성된 타입이라 리액트 element 타입으로 지정했으나, 그렇게 되면 event.target을 이용해서 처리할 때, 해당 필드 타입이 없다는 에러로 고생좀 했습니다. 
찾아보니, 리액트 컴포넌트지만, div태그로 감싸져 있기 때문에 ``` const ref = useRef<HTMLDivElement>(null)```
이렇게 타입을 지정했고 다운 캐스팅을 통해 evet.target을 처리했습니다. ``` e.target as HTMLDivElement ```
(evet.target은 Element모든 이벤트 대상이 요소가 아니다.)

## 🖼 스크린샷

<!-- 있는 경우만 추가해주세요 -->

## ⏰ 실제 소요 시간

2시간
