### PR TITLE
Feat/22/menu modal

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,18 +3,15 @@ import { ThemeProvider } from '@emotion/react'
 import { theme } from './styles'
 import GlobalStyle from './styles/GlobalStyles'
 import { getAllInfo } from './apis/kiosk'
-import { TCategory, TMenu } from 'types'
-import Modal from 'atoms/Modal'
+import { TCategory } from 'types'
 import Header from './components/Header'
 import Page from 'components/Page'
+import styled from '@emotion/styled'
 
 const App = () => {
   // 데이터 필드 변경에 따른 ts타입 나중에 변경 예정
   const [kioskData, setKioskData] = useState<TCategory[]>()
   const [selected, setSelected] = useState<number>(1)
-  const [selectedMenuId, setSelectedMenuId] = useState<number | undefined>()
-  const [selectedMenu, setSelectedMenu] = useState<TMenu>()
-  const [visible, setVisible] = useState(false)
 
   const getData = async () => {
     const data = await getAllInfo()
@@ -29,27 +26,9 @@ const App = () => {
     [],
   )
 
-  const onClickMenu = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const { id } = (e.currentTarget as HTMLElement).dataset
-      setSelectedMenuId(Number(id))
-      const menu = kioskData?.[selected - 1]?.menus.find(
-        (item) => item.id === Number(id),
-      )
-      setSelectedMenu(menu)
-      setVisible(true)
-    },
-    [kioskData, selected],
-  )
-
   useEffect(() => {
     getData()
   }, [])
-
-  // useEffect(() => {
-  //   return
-  //   /setSelectedMenu
-  // }, [selectedMenuId])
 
   return (
     <ThemeProvider theme={theme}>
@@ -60,16 +39,19 @@ const App = () => {
           selected={selected}
           onClickCategory={onClickCategory}></Header>
 
-        <Page
-          menus={kioskData?.[selected - 1].menus}
-          onClickMenu={onClickMenu}></Page>
+        {kioskData ? (
+          <Page menus={kioskData?.[selected - 1].menus}></Page>
+        ) : null}
       </div>
-      <Modal visible={visible} onClose={() => setVisible(false)}>
-        <div></div>
-        {/* <button onClick={() => setVisible(false)}>Close</button> */}
-      </Modal>
     </ThemeProvider>
   )
 }
+
+const MenuModalWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 500px;
+  height: 500px;
+`
 
 export default App

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,16 +3,18 @@ import { ThemeProvider } from '@emotion/react'
 import { theme } from './styles'
 import GlobalStyle from './styles/GlobalStyles'
 import { getAllInfo } from './apis/kiosk'
-import Tab from 'atoms/Tab'
-import styled from '@emotion/styled'
-import TabItem from 'atoms/Tab/TabItem'
-import { TCategory } from 'types'
+import { TCategory, TMenu } from 'types'
+import Modal from 'atoms/Modal'
+import Header from './components/Header'
+import Page from 'components/Page'
 
 const App = () => {
   // 데이터 필드 변경에 따른 ts타입 나중에 변경 예정
   const [kioskData, setKioskData] = useState<TCategory[]>()
   const [selected, setSelected] = useState<number>(1)
   const [selectedMenuId, setSelectedMenuId] = useState<number | undefined>()
+  const [selectedMenu, setSelectedMenu] = useState<TMenu>()
+  const [visible, setVisible] = useState(false)
 
   const getData = async () => {
     const data = await getAllInfo()
@@ -27,62 +29,47 @@ const App = () => {
     [],
   )
 
-  const onClickMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const { id } = (e.target as HTMLElement).dataset
-    setSelectedMenuId(Number(id))
-  }, [])
+  const onClickMenu = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const { id } = (e.currentTarget as HTMLElement).dataset
+      setSelectedMenuId(Number(id))
+      const menu = kioskData?.[selected - 1]?.menus.find(
+        (item) => item.id === Number(id),
+      )
+      setSelectedMenu(menu)
+      setVisible(true)
+    },
+    [kioskData, selected],
+  )
 
   useEffect(() => {
     getData()
   }, [])
 
+  // useEffect(() => {
+  //   return
+  //   /setSelectedMenu
+  // }, [selectedMenuId])
+
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <div className="App">
-        <TabWrapper>
-          {kioskData ? (
-            kioskData.length ? (
-              kioskData.map(({ id, name }) => (
-                <Tab
-                  key={id}
-                  id={id}
-                  category={name}
-                  active={selected === id}
-                  onClickCategory={onClickCategory}
-                />
-              ))
-            ) : (
-              <div>데이터가 없습니다.</div>
-            )
-          ) : (
-            <div>로딩중</div>
-          )}
-        </TabWrapper>
+        <Header
+          categories={kioskData}
+          selected={selected}
+          onClickCategory={onClickCategory}></Header>
 
-        <TabItemWrapper>
-          {kioskData?.[selected - 1]?.menus?.map((menu, index) => (
-            <TabItem
-              key={menu.id}
-              menu={menu}
-              onClickMenu={onClickMenu}
-              rank={index}></TabItem>
-          ))}
-        </TabItemWrapper>
+        <Page
+          menus={kioskData?.[selected - 1].menus}
+          onClickMenu={onClickMenu}></Page>
       </div>
+      <Modal visible={visible} onClose={() => setVisible(false)}>
+        <div></div>
+        {/* <button onClick={() => setVisible(false)}>Close</button> */}
+      </Modal>
     </ThemeProvider>
   )
 }
 
-const TabWrapper = styled.div`
-  margin-top: 30px;
-  display: flex;
-  justify-items: center;
-  justify-content: space-around;
-`
-const TabItemWrapper = styled.div`
-  display: flex;
-  justify-items: flex-start;
-  flex-wrap: wrap;
-`
 export default App

--- a/packages/client/src/Atoms/Button/index.tsx
+++ b/packages/client/src/Atoms/Button/index.tsx
@@ -30,7 +30,7 @@ const Button: React.FC<ButtonProps> = ({
 }
 
 const EButton = styled.button`
-  min-width: 240px;
+  /* min-width: 240px; */
   height: 100px;
   font-size: 32px;
   font-weight: 600;
@@ -39,6 +39,7 @@ const EButton = styled.button`
   align-items: center;
   transition: filter 0.2s;
   border-radius: 20px;
+  background-color: ${({ theme }) => theme.PRIMARY1};
   &:active {
     filter: brightness(80%);
   }

--- a/packages/client/src/Atoms/Modal/index.tsx
+++ b/packages/client/src/Atoms/Modal/index.tsx
@@ -35,8 +35,8 @@ interface Props {
 
 const Modal: React.FC<Props> = ({
   children,
-  width = 500,
-  height = 300,
+  width = 900,
+  height = 800,
   visible = false,
   onClose,
   style,

--- a/packages/client/src/Atoms/Modal/index.tsx
+++ b/packages/client/src/Atoms/Modal/index.tsx
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled'
+import { CSSProperties, useEffect, useMemo } from 'react'
+import ReactDOM from 'react-dom'
+import useClickAway from '../../hooks/useClickAway'
+
+const BackgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 8px;
+  background-color: white;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+`
+
+interface Props {
+  children: React.ReactNode
+  width?: number
+  height?: number
+  style?: CSSProperties
+  visible: boolean
+  onClose(): void
+}
+
+const Modal: React.FC<Props> = ({
+  children,
+  width = 500,
+  height = 300,
+  visible = false,
+  onClose,
+  style,
+  ...props
+}) => {
+  const ref = useClickAway(() => {
+    onClose && onClose()
+  })
+
+  const containerStyle = useMemo(
+    () => ({
+      width,
+      height,
+    }),
+    [width, height],
+  )
+
+  const el = useMemo(() => document.createElement('div'), [])
+  useEffect(() => {
+    document.body.appendChild(el)
+
+    return () => {
+      document.body.removeChild(el)
+    }
+  })
+
+  return ReactDOM.createPortal(
+    <BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
+      <ModalContainer
+        ref={ref}
+        {...props}
+        style={{ ...style, ...containerStyle }}>
+        {children}
+      </ModalContainer>
+    </BackgroundDim>,
+    el,
+  )
+}
+
+export default Modal

--- a/packages/client/src/Atoms/Modal/index.tsx
+++ b/packages/client/src/Atoms/Modal/index.tsx
@@ -3,27 +3,6 @@ import { CSSProperties, useEffect, useMemo } from 'react'
 import ReactDOM from 'react-dom'
 import useClickAway from '../../hooks/useClickAway'
 
-const BackgroundDim = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 1000;
-`
-
-const ModalContainer = styled.div`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 8px;
-  background-color: white;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
-  box-sizing: border-box;
-`
-
 interface Props {
   children: React.ReactNode
   width?: number
@@ -76,4 +55,24 @@ const Modal: React.FC<Props> = ({
   )
 }
 
+const BackgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 8px;
+  background-color: white;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+`
 export default Modal

--- a/packages/client/src/Atoms/Tab/TabItem.tsx
+++ b/packages/client/src/Atoms/Tab/TabItem.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import React, { useState } from 'react'
+import { theme } from '../../styles'
 import { TMenu } from 'types'
 
 interface TProps {
@@ -57,6 +58,9 @@ const Img = styled.img<{ imgUrl2: string }>`
   &:hover {
     content: ${({ imgUrl2 }) => `url(${imgUrl2})`};
   }
+  border-radius: 10px;
+  box-shadow: 4px 4px 4px 4px ${theme.LINE};
+  margin-bottom: 10px;
 `
 
 export default React.memo(TabItem)

--- a/packages/client/src/Atoms/Tab/TabItem.tsx
+++ b/packages/client/src/Atoms/Tab/TabItem.tsx
@@ -1,4 +1,3 @@
-import { css, jsx } from '@emotion/react'
 import styled from '@emotion/styled'
 import React, { useState } from 'react'
 import { TMenu } from 'types'
@@ -6,7 +5,7 @@ import { TMenu } from 'types'
 interface TProps {
   menu: TMenu
   onClickMenu(event: React.MouseEvent<HTMLDivElement>): void
-  rank: number
+  rank?: number
 }
 
 const TabItem: React.FC<TProps> = ({ menu, onClickMenu, rank }) => {
@@ -17,7 +16,7 @@ const TabItem: React.FC<TProps> = ({ menu, onClickMenu, rank }) => {
   return (
     <>
       <TabItemWrapper data-id={id} onClick={onClickMenu}>
-        <RankSpan>{rank + 1}위</RankSpan>
+        {rank !== undefined ? <RankSpan>{rank + 1}위</RankSpan> : null}
         <Img src={imgUrl1} imgUrl2={imgUrl2}></Img>
         <Span>{name}</Span>
         <Span>{price.toLocaleString()}원</Span>

--- a/packages/client/src/Atoms/Tab/TabItem.tsx
+++ b/packages/client/src/Atoms/Tab/TabItem.tsx
@@ -1,6 +1,6 @@
 import { css, jsx } from '@emotion/react'
 import styled from '@emotion/styled'
-import React from 'react'
+import React, { useState } from 'react'
 import { TMenu } from 'types'
 
 interface TProps {
@@ -10,18 +10,19 @@ interface TProps {
 }
 
 const TabItem: React.FC<TProps> = ({ menu, onClickMenu, rank }) => {
+  const [visible, setVisible] = useState(false)
+
   const { id, imgUrl1, imgUrl2, name, price } = menu
 
   return (
-    <TabItemWrapper data-id={id} onClick={onClickMenu}>
-      <RankSpan>{rank + 1}위</RankSpan>
-      <ImgWrapper>
-        <Img className={imgUrl2 ? 'first' : ''} src={imgUrl1} />
-        <Img src={imgUrl2} />
-      </ImgWrapper>
-      <Span>{name}</Span>
-      <Span>{price}</Span>
-    </TabItemWrapper>
+    <>
+      <TabItemWrapper data-id={id} onClick={onClickMenu}>
+        <RankSpan>{rank + 1}위</RankSpan>
+        <Img src={imgUrl1} imgUrl2={imgUrl2}></Img>
+        <Span>{name}</Span>
+        <Span>{price.toLocaleString()}원</Span>
+      </TabItemWrapper>
+    </>
   )
 }
 
@@ -51,23 +52,11 @@ const TabItemWrapper = styled.div`
   position: relative;
 `
 
-const ImgWrapper = styled.div`
+const Img = styled.img<{ imgUrl2: string }>`
   width: 300px;
   height: 300px;
-  position: relative;
   &:hover {
-    & .first {
-      display: none;
-    }
-  }
-`
-
-const Img = styled.img`
-  position: absolute;
-  top: 0;
-  left: 0;
-  &.first {
-    z-index: 1;
+    content: ${({ imgUrl2 }) => `url(${imgUrl2})`};
   }
 `
 

--- a/packages/client/src/Atoms/Tab/index.tsx
+++ b/packages/client/src/Atoms/Tab/index.tsx
@@ -24,7 +24,11 @@ const Tab: React.FC<TabWrapperProps> = ({
       <TabWrapper active={active}>
         <Button
           data-id={id}
-          style={{ backgroundColor: 'white', height: '80px' }}
+          style={{
+            backgroundColor: 'white',
+            height: '80px',
+            minWidth: '240px',
+          }}
           onClick={onClickCategory}
           {...props}>
           {category}

--- a/packages/client/src/Atoms/Tab/index.tsx
+++ b/packages/client/src/Atoms/Tab/index.tsx
@@ -23,6 +23,7 @@ const Tab: React.FC<TabWrapperProps> = ({
     <>
       <TabWrapper active={active}>
         <Button
+          data-id={id}
           style={{ backgroundColor: 'white', height: '80px' }}
           onClick={onClickCategory}
           {...props}>

--- a/packages/client/src/components/Detail/index.tsx
+++ b/packages/client/src/components/Detail/index.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled'
+import { TOptionDetail } from 'types'
+import Iconchecked from '../../images/checked.svg'
+import Iconunchecked from '../../images/unchecked.svg'
+
+interface Props {
+  optionDetail: TOptionDetail
+  index: number
+}
+
+const Detail: React.FC<Props> = ({ optionDetail, index }) => {
+  const { id, name, price } = optionDetail
+  console.log(id, index)
+
+  return (
+    <>
+      <OptionWrapper>
+        <Div>
+          {index + id === id ? (
+            <img src={Iconchecked} />
+          ) : (
+            <img src={Iconunchecked} />
+          )}
+
+          {/* <img src={checked} /> */}
+        </Div>
+        <Div>{name}</Div>
+        <Div>: {price.toLocaleString()}원</Div>
+      </OptionWrapper>
+    </>
+  )
+}
+
+// const OptionWrapper = styled.div`
+//   display: flex;
+//   height: 40px;
+//   align-items: center;
+// `
+const OptionWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  height: 50px;
+  align-items: center;
+  margin: 10px;
+`
+
+const Div = styled.span`
+  margin-left: 10px;
+  font-size: 18px;
+`
+
+export default Detail

--- a/packages/client/src/components/Header/index.tsx
+++ b/packages/client/src/components/Header/index.tsx
@@ -1,0 +1,44 @@
+import { TCategory } from '../../types'
+import Tab from '../../atoms/Tab'
+import styled from '@emotion/styled'
+import Spinner from '../../atoms/Spinner'
+
+interface Props {
+  categories?: TCategory[]
+  selected: number
+  onClickCategory(event: React.MouseEvent<HTMLButtonElement>): void
+}
+
+const Header: React.FC<Props> = ({ categories, onClickCategory, selected }) => {
+  return (
+    <>
+      <TabWrapper>
+        {categories ? (
+          categories.length ? (
+            categories.map(({ id, name }) => (
+              <Tab
+                key={id}
+                id={id}
+                category={name}
+                active={selected === id}
+                onClickCategory={onClickCategory}
+              />
+            ))
+          ) : (
+            <div>데이터가 없습니다.</div>
+          )
+        ) : (
+          <Spinner />
+        )}
+      </TabWrapper>
+    </>
+  )
+}
+
+const TabWrapper = styled.div`
+  margin-top: 30px;
+  display: flex;
+  justify-items: center;
+  justify-content: space-around;
+`
+export default Header

--- a/packages/client/src/components/Header/index.tsx
+++ b/packages/client/src/components/Header/index.tsx
@@ -14,7 +14,7 @@ const Header: React.FC<Props> = ({ categories, onClickCategory, selected }) => {
   return (
     <>
       <HeaderWrapper>
-        <h1>개발자 건강 지킴이</h1>
+        <h1>민수의 헬스 키오스크</h1>
       </HeaderWrapper>
       <TabWrapper>
         {categories ? (

--- a/packages/client/src/components/Header/index.tsx
+++ b/packages/client/src/components/Header/index.tsx
@@ -2,6 +2,7 @@ import { TCategory } from '../../types'
 import Tab from '../../atoms/Tab'
 import styled from '@emotion/styled'
 import Spinner from '../../atoms/Spinner'
+import IconLogo from '../../images/logo.svg'
 
 interface Props {
   categories?: TCategory[]
@@ -12,6 +13,9 @@ interface Props {
 const Header: React.FC<Props> = ({ categories, onClickCategory, selected }) => {
   return (
     <>
+      <HeaderWrapper>
+        <h1>개발자 건강 지킴이</h1>
+      </HeaderWrapper>
       <TabWrapper>
         {categories ? (
           categories.length ? (
@@ -35,6 +39,12 @@ const Header: React.FC<Props> = ({ categories, onClickCategory, selected }) => {
   )
 }
 
+const HeaderWrapper = styled.div`
+  margin: 0 auto;
+  text-align: center;
+  margin-top: 50px;
+  margin-bottom: 50px;
+`
 const TabWrapper = styled.div`
   margin-top: 30px;
   display: flex;

--- a/packages/client/src/components/MenuOption/index.tsx
+++ b/packages/client/src/components/MenuOption/index.tsx
@@ -1,28 +1,85 @@
 import { TMenuOption } from 'types'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from '@emotion/styled'
-import unchecked from '../../images/unchecked.svg'
+import IconUnchecked from '../../images/unchecked.svg'
+import IconChecked from '../../images/checked.svg'
+import OptionDetail from 'components/OptionDetail'
 
 interface Props {
   options: TMenuOption[]
 }
 
 const MenuOption: React.FC<Props> = ({ options }) => {
+  console.log(options)
+
+  const [selectedOption, setSelectedOption] = useState(
+    options.map(({ id }) => ({ optionId: id, detailId: 0 })),
+  )
+  //   const [selectedOption, setSelectedOption] = useState(1)
+
+  const onClickSelectedOption = useCallback(
+    (optionIndex: number, detailId: number) => {
+      //   const { id } = (e.currentTarget as HTMLElement).dataset
+      console.log(selectedOption)
+
+      console.log(optionIndex, detailId)
+      const newSelectedOption = [...selectedOption]
+      newSelectedOption[optionIndex].detailId = detailId
+      setSelectedOption(newSelectedOption)
+    },
+    [selectedOption],
+  )
+
+  //   return (
+  //     <>
+  //       <OptionContainer>
+  //         {options.map(({ detail, name, id }) => (
+  //           <>
+  //             <Div onClick={onClickSelectedOption}>{name}</Div>
+  //             {detail.map(({ id, name, price }) => (
+  //               <OptionWrapper data-id={id} onClick={onClickSelectedOption}>
+  //                 <Div>
+  //                   <Img
+  //                     src={selectedOption === id ? IconChecked : IconUnchecked}
+  //                     alt={name}
+  //                   />
+  //                 </Div>
+
+  //                 <Div>{name}</Div>
+  //                 <Div>{price.toLocaleString()}원</Div>
+  //               </OptionWrapper>
+  //             ))}
+  //           </>
+  //         ))}
+  //       </OptionContainer>
+  //     </>
+  //   )
+  // }
+
   return (
     <>
       <OptionContainer>
-        {options.map(({ detail, name }) => (
+        {options.map(({ detail, name, id }, index) => (
           <>
             <Div>{name}</Div>
-            {detail.map(({ id, name, price }) => (
-              <OptionWrapper data-id={id}>
-                <Div>
-                  <img src={unchecked} />
-                </Div>
+            {detail.map((option) => (
+              <OptionDetail
+                option={option}
+                selectedOption={selectedOption[index]}
+                onClickSelectedOption={(id) => onClickSelectedOption(index, id)}
+              />
 
-                <Div>{name}</Div>
-                <Div>{price.toLocaleString()}원</Div>
-              </OptionWrapper>
+              //   <OptionWrapper data-id={id} onClick={onClickSelectedOption}>
+              //     <Div>
+              //       <Img
+              //         src={selectedOption === id ? IconChecked : IconUnchecked}
+              //         alt={name}
+              //       />
+              //     </Div>
+
+              //     <Div>{name}</Div>
+              //     <Div>{price.toLocaleString()}원</Div>
+              //   </OptionWrapper>
             ))}
           </>
         ))}
@@ -30,16 +87,19 @@ const MenuOption: React.FC<Props> = ({ options }) => {
     </>
   )
 }
+
 const OptionContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-items: center;
   margin-left: 30px;
-  margin-top: 30px;
+  /* margin-top: 30px; */
+  justify-content: center;
 `
 
 const OptionWrapper = styled.div`
-  flex-direction: column;
+  display: flex;
+  flex-direction: row;
   height: 50px;
   align-items: center;
   margin: 10px;
@@ -47,5 +107,7 @@ const OptionWrapper = styled.div`
 
 const Div = styled.span`
   margin-left: 10px;
+  font-size: 18px;
 `
+
 export default MenuOption

--- a/packages/client/src/components/MenuOption/index.tsx
+++ b/packages/client/src/components/MenuOption/index.tsx
@@ -1,8 +1,6 @@
 import { TMenuOption } from 'types'
 import React, { useCallback, useState } from 'react'
 import styled from '@emotion/styled'
-import IconUnchecked from '../../images/unchecked.svg'
-import IconChecked from '../../images/checked.svg'
 import OptionDetail from 'components/OptionDetail'
 
 interface Props {
@@ -10,19 +8,12 @@ interface Props {
 }
 
 const MenuOption: React.FC<Props> = ({ options }) => {
-  console.log(options)
-
   const [selectedOption, setSelectedOption] = useState(
     options.map(({ id }) => ({ optionId: id, detailId: 0 })),
   )
-  //   const [selectedOption, setSelectedOption] = useState(1)
 
   const onClickSelectedOption = useCallback(
     (optionIndex: number, detailId: number) => {
-      //   const { id } = (e.currentTarget as HTMLElement).dataset
-      console.log(selectedOption)
-
-      console.log(optionIndex, detailId)
       const newSelectedOption = [...selectedOption]
       newSelectedOption[optionIndex].detailId = detailId
       setSelectedOption(newSelectedOption)
@@ -30,56 +21,19 @@ const MenuOption: React.FC<Props> = ({ options }) => {
     [selectedOption],
   )
 
-  //   return (
-  //     <>
-  //       <OptionContainer>
-  //         {options.map(({ detail, name, id }) => (
-  //           <>
-  //             <Div onClick={onClickSelectedOption}>{name}</Div>
-  //             {detail.map(({ id, name, price }) => (
-  //               <OptionWrapper data-id={id} onClick={onClickSelectedOption}>
-  //                 <Div>
-  //                   <Img
-  //                     src={selectedOption === id ? IconChecked : IconUnchecked}
-  //                     alt={name}
-  //                   />
-  //                 </Div>
-
-  //                 <Div>{name}</Div>
-  //                 <Div>{price.toLocaleString()}원</Div>
-  //               </OptionWrapper>
-  //             ))}
-  //           </>
-  //         ))}
-  //       </OptionContainer>
-  //     </>
-  //   )
-  // }
-
   return (
     <>
       <OptionContainer>
-        {options.map(({ detail, name, id }, index) => (
+        {options.map(({ detail, name, id }, idx) => (
           <>
             <Div>{name}</Div>
-            {detail.map((option) => (
+            {detail.map((option, index) => (
               <OptionDetail
                 option={option}
-                selectedOption={selectedOption[index]}
-                onClickSelectedOption={(id) => onClickSelectedOption(index, id)}
+                index={index}
+                selectedOption={selectedOption[idx]}
+                onClickSelectedOption={(id) => onClickSelectedOption(idx, id)}
               />
-
-              //   <OptionWrapper data-id={id} onClick={onClickSelectedOption}>
-              //     <Div>
-              //       <Img
-              //         src={selectedOption === id ? IconChecked : IconUnchecked}
-              //         alt={name}
-              //       />
-              //     </Div>
-
-              //     <Div>{name}</Div>
-              //     <Div>{price.toLocaleString()}원</Div>
-              //   </OptionWrapper>
             ))}
           </>
         ))}
@@ -93,16 +47,7 @@ const OptionContainer = styled.div`
   flex-direction: column;
   justify-items: center;
   margin-left: 30px;
-  /* margin-top: 30px; */
   justify-content: center;
-`
-
-const OptionWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  height: 50px;
-  align-items: center;
-  margin: 10px;
 `
 
 const Div = styled.span`

--- a/packages/client/src/components/MenuOption/index.tsx
+++ b/packages/client/src/components/MenuOption/index.tsx
@@ -1,8 +1,6 @@
 import { TMenuOption } from 'types'
 import React from 'react'
-import OptionDetail from 'components/OptionDetail'
 import styled from '@emotion/styled'
-import checked from '../../images/checked.svg'
 import unchecked from '../../images/unchecked.svg'
 
 interface Props {
@@ -12,33 +10,42 @@ interface Props {
 const MenuOption: React.FC<Props> = ({ options }) => {
   return (
     <>
-      {options.map(({ detail, name }) => (
-        <>
-          {name}
-          {detail.map(({ id, name, price }) => (
-            <OptionWrapper data-id={id}>
-              <div>
-                <img src={unchecked} />
-                <img src={checked} />
-              </div>
-              <Span>{name}</Span>
-              <Span>{price.toLocaleString()}</Span>
-            </OptionWrapper>
-          ))}
-        </>
-      ))}
+      <OptionContainer>
+        {options.map(({ detail, name }) => (
+          <>
+            <Div>{name}</Div>
+            {detail.map(({ id, name, price }) => (
+              <OptionWrapper data-id={id}>
+                <Div>
+                  <img src={unchecked} />
+                </Div>
+
+                <Div>{name}</Div>
+                <Div>{price.toLocaleString()}원</Div>
+              </OptionWrapper>
+            ))}
+          </>
+        ))}
+      </OptionContainer>
     </>
   )
 }
+const OptionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-items: center;
+  margin-left: 30px;
+  margin-top: 30px;
+`
 
 const OptionWrapper = styled.div`
-  display: flex;
-  height: 40px;
+  flex-direction: column;
+  height: 50px;
   align-items: center;
+  margin: 10px;
 `
 
-const Span = styled.span`
-  margin: 5px;
+const Div = styled.span`
+  margin-left: 10px;
 `
-
 export default MenuOption

--- a/packages/client/src/components/MenuOption/index.tsx
+++ b/packages/client/src/components/MenuOption/index.tsx
@@ -1,0 +1,44 @@
+import { TMenuOption } from 'types'
+import React from 'react'
+import OptionDetail from 'components/OptionDetail'
+import styled from '@emotion/styled'
+import checked from '../../images/checked.svg'
+import unchecked from '../../images/unchecked.svg'
+
+interface Props {
+  options: TMenuOption[]
+}
+
+const MenuOption: React.FC<Props> = ({ options }) => {
+  return (
+    <>
+      {options.map(({ detail, name }) => (
+        <>
+          {name}
+          {detail.map(({ id, name, price }) => (
+            <OptionWrapper data-id={id}>
+              <div>
+                <img src={unchecked} />
+                <img src={checked} />
+              </div>
+              <Span>{name}</Span>
+              <Span>{price.toLocaleString()}</Span>
+            </OptionWrapper>
+          ))}
+        </>
+      ))}
+    </>
+  )
+}
+
+const OptionWrapper = styled.div`
+  display: flex;
+  height: 40px;
+  align-items: center;
+`
+
+const Span = styled.span`
+  margin: 5px;
+`
+
+export default MenuOption

--- a/packages/client/src/components/MenuOption/index.tsx
+++ b/packages/client/src/components/MenuOption/index.tsx
@@ -1,5 +1,5 @@
 import { TMenuOption } from 'types'
-import React, { useCallback, useState } from 'react'
+import React from 'react'
 import styled from '@emotion/styled'
 import OptionDetail from 'components/OptionDetail'
 
@@ -8,37 +8,15 @@ interface Props {
 }
 
 const MenuOption: React.FC<Props> = ({ options }) => {
-  const [selectedOption, setSelectedOption] = useState(
-    options.map(({ id }) => ({ optionId: id, detailId: 0 })),
-  )
-
-  const onClickSelectedOption = useCallback(
-    (optionIndex: number, detailId: number) => {
-      const newSelectedOption = [...selectedOption]
-      newSelectedOption[optionIndex].detailId = detailId
-      setSelectedOption(newSelectedOption)
-    },
-    [selectedOption],
-  )
-
   return (
-    <>
-      <OptionContainer>
-        {options.map(({ detail, name, id }, idx) => (
-          <>
-            <Div>{name}</Div>
-            {detail.map((option, index) => (
-              <OptionDetail
-                option={option}
-                index={index}
-                selectedOption={selectedOption[idx]}
-                onClickSelectedOption={(id) => onClickSelectedOption(idx, id)}
-              />
-            ))}
-          </>
-        ))}
-      </OptionContainer>
-    </>
+    <OptionContainer>
+      {options.map(({ name, detail }) => (
+        <>
+          <Div>{name}</Div>
+          <OptionDetail detail={detail}></OptionDetail>
+        </>
+      ))}
+    </OptionContainer>
   )
 }
 

--- a/packages/client/src/components/OptionDetail/index.tsx
+++ b/packages/client/src/components/OptionDetail/index.tsx
@@ -1,47 +1,33 @@
 import styled from '@emotion/styled'
-import React, { useCallback, useState } from 'react'
+import React, { useState } from 'react'
 import { TOptionDetail } from 'types'
 import IconUnchecked from '../../images/unchecked.svg'
 import IconChecked from '../../images/checked.svg'
 
 interface Props {
-  option: TOptionDetail
-  selectedOption: { optionId: number; detailId: number }
-  onClickSelectedOption(id: number): void
-  index: number
+  detail: TOptionDetail[]
 }
 
-const OptionDetail: React.FC<Props> = ({
-  option,
-  selectedOption,
-  onClickSelectedOption,
-  index,
-}) => {
-  const { id, name, price } = option
-
-  console.log(selectedOption.detailId)
+const OptionDetail: React.FC<Props> = ({ detail }) => {
+  const [selectedOption, setSelectedOption] = useState(detail[0])
+  const handleSeletedDetail = (option: TOptionDetail) => {
+    setSelectedOption(option)
+  }
 
   return (
     <>
-      <OptionWrapper>
-        {selectedOption.detailId === 0 ? (
-          <>
-            <Div onClick={() => onClickSelectedOption(id)}>
-              <img src={index === 0 ? IconChecked : IconUnchecked} alt={name} />
-            </Div>
-          </>
-        ) : (
-          <Div onClick={() => onClickSelectedOption(id)}>
-            <img
-              src={selectedOption.detailId === id ? IconChecked : IconUnchecked}
-              alt={name}
-            />
+      {detail.map((option) => (
+        <OptionWrapper onClick={() => handleSeletedDetail(option)}>
+          <Div>
+            {selectedOption.id === option.id ? (
+              <img src={IconChecked} />
+            ) : (
+              <img src={IconUnchecked} />
+            )}
           </Div>
-        )}
-
-        <Div>{name}</Div>
-        <Div>{price.toLocaleString()}원</Div>
-      </OptionWrapper>
+          <Div>{option.name}</Div>
+        </OptionWrapper>
+      ))}
     </>
   )
 }

--- a/packages/client/src/components/OptionDetail/index.tsx
+++ b/packages/client/src/components/OptionDetail/index.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled'
+import React, { useCallback, useState } from 'react'
+import { TOptionDetail } from 'types'
+import IconUnchecked from '../../images/unchecked.svg'
+import IconChecked from '../../images/checked.svg'
+
+interface Props {
+  option: TOptionDetail
+  selectedOption: { optionId: number; detailId: number }
+  onClickSelectedOption(id: number): void
+}
+
+const OptionDetail: React.FC<Props> = ({
+  option,
+  selectedOption,
+  onClickSelectedOption,
+}) => {
+  const [toggle, setToggle] = useState(selectedOption)
+  const [soption, setSoption] = useState(0)
+
+  const ClickSelectedOption = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const { id } = (e.currentTarget as HTMLElement).dataset
+      console.log(id)
+      setSoption(Number(id))
+    },
+    [selectedOption],
+  )
+
+  const { id, name, price } = option
+
+  return (
+    <>
+      <OptionWrapper>
+        <Div onClick={() => onClickSelectedOption(id)}>
+          <img
+            src={selectedOption.detailId === id ? IconChecked : IconUnchecked}
+            alt={name}
+          />
+        </Div>
+
+        <Div>{name}</Div>
+        <Div>{price.toLocaleString()}원</Div>
+      </OptionWrapper>
+    </>
+  )
+}
+
+const OptionWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  height: 50px;
+  align-items: center;
+  margin: 10px;
+`
+
+const Div = styled.span`
+  margin-left: 10px;
+  font-size: 18px;
+`
+
+export default OptionDetail

--- a/packages/client/src/components/OptionDetail/index.tsx
+++ b/packages/client/src/components/OptionDetail/index.tsx
@@ -8,36 +8,36 @@ interface Props {
   option: TOptionDetail
   selectedOption: { optionId: number; detailId: number }
   onClickSelectedOption(id: number): void
+  index: number
 }
 
 const OptionDetail: React.FC<Props> = ({
   option,
   selectedOption,
   onClickSelectedOption,
+  index,
 }) => {
-  const [toggle, setToggle] = useState(selectedOption)
-  const [soption, setSoption] = useState(0)
-
-  const ClickSelectedOption = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const { id } = (e.currentTarget as HTMLElement).dataset
-      console.log(id)
-      setSoption(Number(id))
-    },
-    [selectedOption],
-  )
-
   const { id, name, price } = option
+
+  console.log(selectedOption.detailId)
 
   return (
     <>
       <OptionWrapper>
-        <Div onClick={() => onClickSelectedOption(id)}>
-          <img
-            src={selectedOption.detailId === id ? IconChecked : IconUnchecked}
-            alt={name}
-          />
-        </Div>
+        {selectedOption.detailId === 0 ? (
+          <>
+            <Div onClick={() => onClickSelectedOption(id)}>
+              <img src={index === 0 ? IconChecked : IconUnchecked} alt={name} />
+            </Div>
+          </>
+        ) : (
+          <Div onClick={() => onClickSelectedOption(id)}>
+            <img
+              src={selectedOption.detailId === id ? IconChecked : IconUnchecked}
+              alt={name}
+            />
+          </Div>
+        )}
 
         <Div>{name}</Div>
         <Div>{price.toLocaleString()}원</Div>

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -14,15 +14,25 @@ interface Props {
 }
 
 const Page: React.FC<Props> = ({ menus }) => {
-  const [selectedMenuId, setSelectedMenuId] = useState<number>()
   const [selectedMenu, setSelectedMenu] = useState<TMenu>()
   const [visible, setVisible] = useState(false)
   const [count, setCount] = useState(1)
 
+  // 옵션 클릭 시 해당 정보 객체로 받아오는 로직
+  // 나중에 구현 예정
+  //   const [selectedOption, setSelectedOption] = useState<any>()
+  //   const handleSelectedOption = (option: TOptionDetail) => {
+  // const selectedOptionFilter = selectedOption?.filter(
+  //   ({ id }: { id: number }) => option.id !== id,
+  // )
+  // const newSelectedOption = [...selectedOptionFilter, option]
+  // setSelectedOption(option)
+  //   }
+
   const onClickMenu = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const { id } = (e.currentTarget as HTMLElement).dataset
-      setSelectedMenuId(Number(id))
+      //   setSelectedMenuId(Number(id))
       const menu = menus.find((item) => item.id === Number(id))
       setSelectedMenu(menu)
       setVisible(true)
@@ -45,6 +55,10 @@ const Page: React.FC<Props> = ({ menus }) => {
   const totalPrice = useMemo(() => {
     return selectedMenu?.price ? selectedMenu.price * count : 0
   }, [selectedMenu, count])
+
+  useEffect(() => {
+    setCount(1)
+  }, [visible])
 
   return (
     <>
@@ -97,15 +111,11 @@ const Page: React.FC<Props> = ({ menus }) => {
           </CheckBox>
         </MenuModalWrapper>
 
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            marginTop: '100px',
-          }}>
-          <Button style={{ width: '300px' }}>{totalPrice} 담기</Button>
-        </div>
-        {/* <button onClick={() => setVisible(false)}>Close</button> */}
+        <ButtonWrapper>
+          <Button onClick={() => setVisible(false)} style={{ width: '300px' }}>
+            {totalPrice.toLocaleString()}원 담기
+          </Button>
+        </ButtonWrapper>
       </Modal>
     </>
   )
@@ -131,6 +141,13 @@ const Span = styled.span`
   width: 150px;
   text-align: center;
 `
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 100px;
+`
+
 const CheckBox = styled.div`
   margin-top: 30px;
   display: flex;

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -4,6 +4,11 @@ import TabItem from '../../atoms/Tab/TabItem'
 import styled from '@emotion/styled'
 import Modal from 'atoms/Modal'
 import MenuOption from 'components/MenuOption'
+import Button from 'atoms/Button'
+import IconPlus from '../../images/plus.svg'
+import IconMinus from '../../images/minus.svg'
+import { theme } from '../../styles'
+
 interface Props {
   menus: TMenu[]
 }
@@ -12,6 +17,7 @@ const Page: React.FC<Props> = ({ menus }) => {
   const [selectedMenuId, setSelectedMenuId] = useState<number>()
   const [selectedMenu, setSelectedMenu] = useState<TMenu>()
   const [visible, setVisible] = useState(false)
+  const [count, setCount] = useState(0)
 
   const onClickMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const { id } = (e.currentTarget as HTMLElement).dataset
@@ -19,6 +25,14 @@ const Page: React.FC<Props> = ({ menus }) => {
     const menu = menus.find((item) => item.id === Number(id))
     setSelectedMenu(menu)
     setVisible(true)
+  }, [])
+
+  const onIncreaseCount = useCallback(() => {
+    setCount((count) => count + 1)
+  }, [])
+
+  const onDecreaseCount = useCallback(() => {
+    setCount((count) => count - 1)
   }, [])
 
   return (
@@ -35,18 +49,52 @@ const Page: React.FC<Props> = ({ menus }) => {
 
       <Modal visible={visible} onClose={() => setVisible(false)}>
         <MenuModalWrapper>
-          {selectedMenu ? (
-            <>
-              <TabItem
-                key={selectedMenu.id}
-                menu={selectedMenu}
-                onClickMenu={onClickMenu}
-              />
+          <MenuInfoWrapper>
+            {selectedMenu ? (
+              <>
+                <TabItem
+                  key={selectedMenu.id}
+                  menu={selectedMenu}
+                  onClickMenu={onClickMenu}
+                />
 
-              <MenuOption options={selectedMenu.options} />
-            </>
-          ) : null}
+                <MenuOption options={selectedMenu.options} />
+              </>
+            ) : null}
+          </MenuInfoWrapper>
+
+          <CheckBox>
+            <Span>수량</Span>
+
+            <Button
+              onClick={onIncreaseCount}
+              style={{
+                width: '80px',
+                height: '50px',
+              }}>
+              <img src={IconPlus} />
+            </Button>
+            <Span>{count} 개</Span>
+            <Button
+              onClick={onDecreaseCount}
+              style={{
+                width: '80px',
+                height: '50px',
+                backgroundColor: `${theme.ERROR}`,
+              }}>
+              <img src={IconMinus} />
+            </Button>
+          </CheckBox>
         </MenuModalWrapper>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            marginTop: '100px',
+          }}>
+          <Button style={{ width: '300px' }}>400원 담기</Button>
+        </div>
         {/* <button onClick={() => setVisible(false)}>Close</button> */}
       </Modal>
     </>
@@ -58,10 +106,29 @@ const MenuModalWrapper = styled.div`
   flex-direction: column;
 `
 
+const MenuInfoWrapper = styled.div`
+  display: flex;
+`
+
 const TabItemWrapper = styled.div`
   display: flex;
   justify-items: flex-start;
   flex-wrap: wrap;
+`
+
+const Span = styled.span`
+  font-size: 30px;
+  width: 120px;
+  text-align: center;
+`
+const CheckBox = styled.div`
+  margin-top: 30px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin: 20px;
+
+  align-items: center;
 `
 
 export default Page

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const Page: React.FC<Props> = ({ menus }) => {
-  const [selectedMenu, setSelectedMenu] = useState<TMenu>()
+  const [selectedMenu, setSelectedMenu] = useState<TMenu | undefined>()
   const [visible, setVisible] = useState(false)
   const [count, setCount] = useState(1)
 
@@ -32,7 +32,6 @@ const Page: React.FC<Props> = ({ menus }) => {
   const onClickMenu = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const { id } = (e.currentTarget as HTMLElement).dataset
-      //   setSelectedMenuId(Number(id))
       const menu = menus.find((item) => item.id === Number(id))
       setSelectedMenu(menu)
       setVisible(true)
@@ -56,9 +55,11 @@ const Page: React.FC<Props> = ({ menus }) => {
     return selectedMenu?.price ? selectedMenu.price * count : 0
   }, [selectedMenu, count])
 
-  useEffect(() => {
+  const handleInit = () => {
+    setVisible(false)
     setCount(1)
-  }, [visible])
+    setSelectedMenu(undefined)
+  }
 
   return (
     <>
@@ -72,7 +73,7 @@ const Page: React.FC<Props> = ({ menus }) => {
         ))}
       </TabItemWrapper>
 
-      <Modal visible={visible} onClose={() => setVisible(false)}>
+      <Modal visible={visible} onClose={handleInit}>
         <MenuModalWrapper>
           <MenuInfoWrapper>
             {selectedMenu ? (
@@ -112,7 +113,7 @@ const Page: React.FC<Props> = ({ menus }) => {
         </MenuModalWrapper>
 
         <ButtonWrapper>
-          <Button onClick={() => setVisible(false)} style={{ width: '300px' }}>
+          <Button onClick={handleInit} style={{ width: '300px' }}>
             {totalPrice.toLocaleString()}원 담기
           </Button>
         </ButtonWrapper>

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -1,5 +1,5 @@
 import { TMenu } from 'types'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import TabItem from '../../atoms/Tab/TabItem'
 import styled from '@emotion/styled'
 import Modal from 'atoms/Modal'
@@ -17,23 +17,34 @@ const Page: React.FC<Props> = ({ menus }) => {
   const [selectedMenuId, setSelectedMenuId] = useState<number>()
   const [selectedMenu, setSelectedMenu] = useState<TMenu>()
   const [visible, setVisible] = useState(false)
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(1)
 
-  const onClickMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const { id } = (e.currentTarget as HTMLElement).dataset
-    setSelectedMenuId(Number(id))
-    const menu = menus.find((item) => item.id === Number(id))
-    setSelectedMenu(menu)
-    setVisible(true)
-  }, [])
+  const onClickMenu = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const { id } = (e.currentTarget as HTMLElement).dataset
+      setSelectedMenuId(Number(id))
+      const menu = menus.find((item) => item.id === Number(id))
+      setSelectedMenu(menu)
+      setVisible(true)
+    },
+    [menus],
+  )
 
   const onIncreaseCount = useCallback(() => {
+    if (count >= 10) return
+
     setCount((count) => count + 1)
-  }, [])
+  }, [count])
 
   const onDecreaseCount = useCallback(() => {
+    if (count <= 1) return
+
     setCount((count) => count - 1)
-  }, [])
+  }, [count])
+
+  const totalPrice = useMemo(() => {
+    return selectedMenu?.price ? selectedMenu.price * count : 0
+  }, [selectedMenu, count])
 
   return (
     <>
@@ -57,7 +68,6 @@ const Page: React.FC<Props> = ({ menus }) => {
                   menu={selectedMenu}
                   onClickMenu={onClickMenu}
                 />
-
                 <MenuOption options={selectedMenu.options} />
               </>
             ) : null}
@@ -74,7 +84,7 @@ const Page: React.FC<Props> = ({ menus }) => {
               }}>
               <img src={IconPlus} />
             </Button>
-            <Span>{count} 개</Span>
+            <Span>{count < 10 ? count : '최대 10'} 개</Span>
             <Button
               onClick={onDecreaseCount}
               style={{
@@ -93,7 +103,7 @@ const Page: React.FC<Props> = ({ menus }) => {
             justifyContent: 'center',
             marginTop: '100px',
           }}>
-          <Button style={{ width: '300px' }}>400원 담기</Button>
+          <Button style={{ width: '300px' }}>{totalPrice} 담기</Button>
         </div>
         {/* <button onClick={() => setVisible(false)}>Close</button> */}
       </Modal>
@@ -118,7 +128,7 @@ const TabItemWrapper = styled.div`
 
 const Span = styled.span`
   font-size: 30px;
-  width: 120px;
+  width: 150px;
   text-align: center;
 `
 const CheckBox = styled.div`

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -1,13 +1,26 @@
 import { TMenu } from 'types'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import TabItem from '../../atoms/Tab/TabItem'
 import styled from '@emotion/styled'
+import Modal from 'atoms/Modal'
+import MenuOption from 'components/MenuOption'
 interface Props {
-  menus?: TMenu[]
-  onClickMenu(event: React.MouseEvent<HTMLDivElement>): void
+  menus: TMenu[]
 }
 
-const Page: React.FC<Props> = ({ menus, onClickMenu }) => {
+const Page: React.FC<Props> = ({ menus }) => {
+  const [selectedMenuId, setSelectedMenuId] = useState<number>()
+  const [selectedMenu, setSelectedMenu] = useState<TMenu>()
+  const [visible, setVisible] = useState(false)
+
+  const onClickMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const { id } = (e.currentTarget as HTMLElement).dataset
+    setSelectedMenuId(Number(id))
+    const menu = menus.find((item) => item.id === Number(id))
+    setSelectedMenu(menu)
+    setVisible(true)
+  }, [])
+
   return (
     <>
       <TabItemWrapper>
@@ -19,9 +32,31 @@ const Page: React.FC<Props> = ({ menus, onClickMenu }) => {
             rank={index}></TabItem>
         ))}
       </TabItemWrapper>
+
+      <Modal visible={visible} onClose={() => setVisible(false)}>
+        <MenuModalWrapper>
+          {selectedMenu ? (
+            <>
+              <TabItem
+                key={selectedMenu.id}
+                menu={selectedMenu}
+                onClickMenu={onClickMenu}
+              />
+
+              <MenuOption options={selectedMenu.options} />
+            </>
+          ) : null}
+        </MenuModalWrapper>
+        {/* <button onClick={() => setVisible(false)}>Close</button> */}
+      </Modal>
     </>
   )
 }
+
+const MenuModalWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`
 
 const TabItemWrapper = styled.div`
   display: flex;

--- a/packages/client/src/components/Page/index.tsx
+++ b/packages/client/src/components/Page/index.tsx
@@ -1,0 +1,32 @@
+import { TMenu } from 'types'
+import React from 'react'
+import TabItem from '../../atoms/Tab/TabItem'
+import styled from '@emotion/styled'
+interface Props {
+  menus?: TMenu[]
+  onClickMenu(event: React.MouseEvent<HTMLDivElement>): void
+}
+
+const Page: React.FC<Props> = ({ menus, onClickMenu }) => {
+  return (
+    <>
+      <TabItemWrapper>
+        {menus?.map((menu, index) => (
+          <TabItem
+            key={menu.id}
+            menu={menu}
+            onClickMenu={onClickMenu}
+            rank={index}></TabItem>
+        ))}
+      </TabItemWrapper>
+    </>
+  )
+}
+
+const TabItemWrapper = styled.div`
+  display: flex;
+  justify-items: flex-start;
+  flex-wrap: wrap;
+`
+
+export default Page

--- a/packages/client/src/hooks/useClickAway.tsx
+++ b/packages/client/src/hooks/useClickAway.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useRef } from 'react'
+
+const useClickAway = (handler: () => void) => {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const handleEvent = (e: MouseEvent) => {
+      !element.contains(e.target as HTMLDivElement) && handler()
+    }
+
+    document.addEventListener('mousedown', handleEvent)
+
+    return () => document.removeEventListener('mousedown', handleEvent)
+  })
+
+  return ref
+}
+
+export default useClickAway

--- a/packages/client/src/images/checked.svg
+++ b/packages/client/src/images/checked.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="20" r="20" fill="#5EBEBB"/>
+<circle cx="20" cy="20" r="8" fill="white"/>
+</svg>

--- a/packages/client/src/images/minus.svg
+++ b/packages/client/src/images/minus.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.33333 8.5H12.6667" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/client/src/images/plus.svg
+++ b/packages/client/src/images/plus.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 5V19" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 12H19" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/client/src/images/unchecked.svg
+++ b/packages/client/src/images/unchecked.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="20" r="20" fill="#D7D7D7"/>
+<circle cx="20" cy="20" r="8" fill="white"/>
+</svg>

--- a/packages/server/src/app.service.ts
+++ b/packages/server/src/app.service.ts
@@ -40,12 +40,12 @@ export class AppService {
                   name: '사이즈',
                   detail: [
                     {
-                      id: 1,
+                      id: 3,
                       name: '5 kg',
                       price: 0,
                     },
                     {
-                      id: 2,
+                      id: 4,
                       name: '10 kg',
                       price: 15000,
                     },
@@ -84,12 +84,12 @@ export class AppService {
                   name: '사이즈',
                   detail: [
                     {
-                      id: 1,
+                      id: 3,
                       name: '5 kg',
                       price: 0,
                     },
                     {
-                      id: 2,
+                      id: 4,
                       name: '10 kg',
                       price: 15000,
                     },


### PR DESCRIPTION
# 💬 세부사항

## 📎 관련 이슈

close #22 

## 😭 어려웠던 점 or 참고 사항
메뉴정보와 디테일정보를 포함하고 있는 로직이 별로 없어서 한 컴포넌트에서 이중map으로 컴포넌트 관리를 처음에 구상했습니다.
그러다보니 옵션 선택에 따른 토글 처리 로직이 꼬여서 억지로 끼워 맞추다가 이건 아니다 싶어 컴포넌트를 분리했습니다.
그리고 현재 컴포넌트 구조에서 상품 갯수에 따른 상품 가격 처리는 완료했는데 옵션에 따른 가격처리는 다소 복잡하여 나중에 구현 하기로 했습니다.

## 🖼 스크린샷
기본 디폴트 옵션
<img width="1046" alt="스크린샷 2022-08-09 오후 2 33 29" src="https://user-images.githubusercontent.com/52727782/183572039-04618076-f28d-4b16-8602-1263a2bdd0fc.png">

선택에 따른 토글 처리
<img width="1046" alt="스크린샷 2022-08-09 오후 2 33 39" src="https://user-images.githubusercontent.com/52727782/183572061-ae151623-7a53-45e5-bf0e-93fe19985b62.png">


## ⏰ 실제 소요 시간
8시간