### PR TITLE
Refactor/30/context api

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -2,11 +2,10 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { ThemeProvider } from '@emotion/react'
 import { theme } from './utils/styles'
 import GlobalStyle from './utils/styles/GlobalStyles'
-import { getAllInfo } from './apis/kiosk'
+import { getAllInfoAPI } from './apis/kiosk'
 import { TCategory } from 'utils/types'
 import Header from './components/templates/Header'
 import Main from 'components/templates/main'
-import styled from '@emotion/styled'
 
 const App = () => {
   // 데이터 필드 변경에 따른 ts타입 나중에 변경 예정
@@ -14,7 +13,7 @@ const App = () => {
   const [selected, setSelected] = useState<number>(1)
 
   const getData = async () => {
-    const data = await getAllInfo()
+    const data = await getAllInfoAPI()
     setKioskData(data)
   }
 
@@ -46,12 +45,5 @@ const App = () => {
     </ThemeProvider>
   )
 }
-
-const MenuModalWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 500px;
-  height: 500px;
-`
 
 export default App

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -6,6 +6,8 @@ import { getAllInfoAPI } from './apis/kiosk'
 import { TCategory } from 'utils/types'
 import Header from './components/templates/Header'
 import Main from 'components/templates/main'
+import Footer from 'components/templates/footer'
+import CartProvider from 'contexts/CartProvider'
 
 const App = () => {
   // 데이터 필드 변경에 따른 ts타입 나중에 변경 예정
@@ -37,10 +39,13 @@ const App = () => {
           categories={kioskData}
           selected={selected}
           onClickCategory={onClickCategory}></Header>
+        <CartProvider>
+          {kioskData ? (
+            <Main menus={kioskData?.[selected - 1].menus}></Main>
+          ) : null}
 
-        {kioskData ? (
-          <Main menus={kioskData?.[selected - 1].menus}></Main>
-        ) : null}
+          <Footer></Footer>
+        </CartProvider>
       </div>
     </ThemeProvider>
   )

--- a/packages/client/src/apis/kiosk.ts
+++ b/packages/client/src/apis/kiosk.ts
@@ -1,7 +1,7 @@
 import { axiosInstance } from './util'
 import { TCategory } from 'utils/types'
 
-export const getAllInfo = async (): Promise<TCategory[] | undefined> => {
+export const getAllInfoAPI = async (): Promise<TCategory[] | undefined> => {
   try {
     const { data, status } = await axiosInstance.get('categories')
 

--- a/packages/client/src/apis/kiosk.ts
+++ b/packages/client/src/apis/kiosk.ts
@@ -1,9 +1,21 @@
 import { axiosInstance } from './util'
-import { TCategory } from 'utils/types'
+import { TCategory, TMenu } from 'utils/types'
 
 export const getAllInfoAPI = async (): Promise<TCategory[] | undefined> => {
   try {
     const { data, status } = await axiosInstance.get('categories')
+
+    if (status === 200) {
+      return data
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const getMenuAPI = async (id: number): Promise<TMenu | undefined> => {
+  try {
+    const { data, status } = await axiosInstance.get(`menus/${id}`)
 
     if (status === 200) {
       return data

--- a/packages/client/src/components/molecules/MenuOption/index.tsx
+++ b/packages/client/src/components/molecules/MenuOption/index.tsx
@@ -10,11 +10,11 @@ interface Props {
 const MenuOption: React.FC<Props> = ({ options }) => {
   return (
     <OptionContainer>
-      {options.map(({ name, detail }) => (
-        <>
-          <Div>{name}</Div>
-          <OptionDetail detail={detail}></OptionDetail>
-        </>
+      {options.map(({ name, details, id }, index) => (
+        <div key={`${index}${id}`}>
+          <Span>{name}</Span>
+          <OptionDetail details={details}></OptionDetail>
+        </div>
       ))}
     </OptionContainer>
   )
@@ -28,7 +28,7 @@ const OptionContainer = styled.div`
   justify-content: center;
 `
 
-const Div = styled.span`
+const Span = styled.span`
   margin-left: 10px;
   font-size: 18px;
 `

--- a/packages/client/src/components/molecules/MenuOption/index.tsx
+++ b/packages/client/src/components/molecules/MenuOption/index.tsx
@@ -9,6 +9,7 @@ import { theme } from '../../../utils/styles'
 interface Props {
   options: TMenuOption[]
   menuPrice: number
+  onClose: (data: any) => void
 }
 
 interface SelectedProps {
@@ -16,7 +17,7 @@ interface SelectedProps {
   option: TOptionDetail
 }
 
-const MenuOption: React.FC<Props> = ({ options, menuPrice }) => {
+const MenuOption: React.FC<Props> = ({ options, menuPrice, onClose }) => {
   const [count, setCount] = useState(1)
   const [selectedOption, setSelectedOption] = useState<SelectedProps[]>()
 
@@ -42,6 +43,11 @@ const MenuOption: React.FC<Props> = ({ options, menuPrice }) => {
 
     setCount((count) => count - 1)
   }, [count])
+
+  const addCart = () => {
+    const data = { count, selectedOption }
+    onClose(data)
+  }
 
   const handleSelectedOption = (data: SelectedProps) => {
     const result = selectedOption?.every(
@@ -99,7 +105,7 @@ const MenuOption: React.FC<Props> = ({ options, menuPrice }) => {
       </CheckBox>
 
       <ButtonWrapper>
-        <Button style={{ width: '300px' }}>
+        <Button onClick={addCart} style={{ width: '300px' }}>
           {totalPrice.toLocaleString()}원 담기
         </Button>
       </ButtonWrapper>
@@ -110,7 +116,6 @@ const MenuOption: React.FC<Props> = ({ options, menuPrice }) => {
 const OptionContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-left: 30px;
   margin: 28px;
 `
 

--- a/packages/client/src/components/molecules/MenuOption/index.tsx
+++ b/packages/client/src/components/molecules/MenuOption/index.tsx
@@ -84,7 +84,7 @@ const MenuOption: React.FC<Props> = ({ options, menuPrice }) => {
             width: '80px',
             height: '50px',
           }}>
-          <img src={IconPlus} />
+          <img src={IconPlus} alt="IconPlus" />
         </Button>
         <Span>{count < 10 ? count : '최대 10'} 개</Span>
         <Button
@@ -94,7 +94,7 @@ const MenuOption: React.FC<Props> = ({ options, menuPrice }) => {
             height: '50px',
             backgroundColor: `${theme.ERROR}`,
           }}>
-          <img src={IconMinus} />
+          <img src={IconMinus} alt="IconMinus" />
         </Button>
       </CheckBox>
 
@@ -111,6 +111,7 @@ const OptionContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin-left: 30px;
+  margin: 28px;
 `
 
 const Title = styled.span`
@@ -133,7 +134,6 @@ const CheckBox = styled.div`
   margin-top: 30px;
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
   margin: 20px;
   align-items: center;
 `

--- a/packages/client/src/components/molecules/MenuOption/index.tsx
+++ b/packages/client/src/components/molecules/MenuOption/index.tsx
@@ -1,21 +1,108 @@
-import { TMenuOption } from 'utils/types'
-import React from 'react'
+import { TMenuOption, TOptionDetail } from 'utils/types'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from '@emotion/styled'
 import OptionDetail from 'components/molecules/OptionDetail'
-
+import Button from 'components/atoms/Button'
+import IconPlus from '../../../utils/images/plus.svg'
+import IconMinus from '../../../utils/images/minus.svg'
+import { theme } from '../../../utils/styles'
 interface Props {
   options: TMenuOption[]
+  menuPrice: number
 }
 
-const MenuOption: React.FC<Props> = ({ options }) => {
+interface SelectedProps {
+  optionId: number
+  option: TOptionDetail
+}
+
+const MenuOption: React.FC<Props> = ({ options, menuPrice }) => {
+  const [count, setCount] = useState(1)
+  const [selectedOption, setSelectedOption] = useState<SelectedProps[]>()
+
+  useEffect(() => {
+    const data = options.map(({ id }, index) => {
+      return {
+        optionId: id,
+        option: options[index].details[0],
+      }
+    })
+
+    setSelectedOption(data)
+  }, [options])
+
+  const onIncreaseCount = useCallback(() => {
+    if (count >= 10) return
+
+    setCount((count) => count + 1)
+  }, [count])
+
+  const onDecreaseCount = useCallback(() => {
+    if (count <= 1) return
+
+    setCount((count) => count - 1)
+  }, [count])
+
+  const handleSelectedOption = (data: SelectedProps) => {
+    const result = selectedOption?.every(
+      ({ option }) => option.id !== data.option.id,
+    )
+    if (!result) return
+
+    const newSelectedOption = selectedOption?.filter(
+      ({ optionId }) => optionId !== data.optionId,
+    )
+    newSelectedOption?.push({ optionId: data.optionId, option: data.option })
+    setSelectedOption(newSelectedOption)
+  }
+  const totalPrice = useMemo(() => {
+    const optionPrice = selectedOption?.reduce(
+      (acc, cur) => acc + cur.option.price,
+      0,
+    )
+
+    return (menuPrice + Number(optionPrice)) * count
+  }, [count, menuPrice, selectedOption])
+
   return (
     <OptionContainer>
       {options.map(({ name, details, id }, index) => (
         <div key={`${index}${id}`}>
-          <Span>{name}</Span>
-          <OptionDetail details={details}></OptionDetail>
+          <Title>{name}</Title>
+          <OptionDetail
+            optionId={id}
+            details={details}
+            handleSelectedOption={handleSelectedOption}></OptionDetail>
         </div>
       ))}
+
+      <CheckBox>
+        <Span>수량</Span>
+        <Button
+          onClick={onIncreaseCount}
+          style={{
+            width: '80px',
+            height: '50px',
+          }}>
+          <img src={IconPlus} />
+        </Button>
+        <Span>{count < 10 ? count : '최대 10'} 개</Span>
+        <Button
+          onClick={onDecreaseCount}
+          style={{
+            width: '80px',
+            height: '50px',
+            backgroundColor: `${theme.ERROR}`,
+          }}>
+          <img src={IconMinus} />
+        </Button>
+      </CheckBox>
+
+      <ButtonWrapper>
+        <Button style={{ width: '300px' }}>
+          {totalPrice.toLocaleString()}원 담기
+        </Button>
+      </ButtonWrapper>
     </OptionContainer>
   )
 }
@@ -23,14 +110,32 @@ const MenuOption: React.FC<Props> = ({ options }) => {
 const OptionContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-items: center;
   margin-left: 30px;
-  justify-content: center;
 `
 
-const Span = styled.span`
+const Title = styled.span`
   margin-left: 10px;
   font-size: 18px;
+`
+const Span = styled.span`
+  font-size: 30px;
+  width: 150px;
+  text-align: center;
+`
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 100px;
+`
+
+const CheckBox = styled.div`
+  margin-top: 30px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin: 20px;
+  align-items: center;
 `
 
 export default MenuOption

--- a/packages/client/src/components/molecules/OptionDetail/index.tsx
+++ b/packages/client/src/components/molecules/OptionDetail/index.tsx
@@ -4,28 +4,50 @@ import { TOptionDetail } from 'utils/types'
 import IconUnchecked from '../../../utils/images/unchecked.svg'
 import IconChecked from '../../../utils/images/checked.svg'
 
-interface Props {
-  details: TOptionDetail[]
+interface SelectedProps {
+  optionId: number
+  option: TOptionDetail
 }
 
-const OptionDetail: React.FC<Props> = ({ details }) => {
-  const [selectedOption, setSelectedOption] = useState(details[0])
-  const handleSeletedDetail = (option: TOptionDetail) => {
-    setSelectedOption(option)
+interface Props {
+  details: TOptionDetail[]
+  optionId: number
+  handleSelectedOption(option: SelectedProps): void
+}
+
+const OptionDetail: React.FC<Props> = ({
+  details,
+  optionId,
+  handleSelectedOption,
+}) => {
+  const [checkedOption, setCheckedOption] = useState(details[0].id)
+
+  const clickEvent = (
+    id: number,
+    optionId: number,
+    name: string,
+    price: number,
+  ) => {
+    const data = { optionId, option: { id, name, price } }
+    handleSelectedOption(data)
+    setCheckedOption(id)
   }
 
   return (
     <>
-      {details.map((option) => (
-        <OptionWrapper onClick={() => handleSeletedDetail(option)}>
+      {details.map(({ id, name, price }) => (
+        <OptionWrapper
+          key={`detail.${id}`}
+          onClick={() => clickEvent(id, optionId, name, price)}>
           <Div>
-            {selectedOption.id === option.id ? (
-              <img src={IconChecked} />
+            {checkedOption === id ? (
+              <img src={IconChecked} alt={'IconChecked'} />
             ) : (
-              <img src={IconUnchecked} />
+              <img src={IconUnchecked} alt={'IconUnChecked'} />
             )}
           </Div>
-          <Div>{option.name}</Div>
+          <Div>{name}</Div>
+          <Div>{price.toLocaleString()}원</Div>
         </OptionWrapper>
       ))}
     </>

--- a/packages/client/src/components/molecules/OptionDetail/index.tsx
+++ b/packages/client/src/components/molecules/OptionDetail/index.tsx
@@ -5,18 +5,18 @@ import IconUnchecked from '../../../utils/images/unchecked.svg'
 import IconChecked from '../../../utils/images/checked.svg'
 
 interface Props {
-  detail: TOptionDetail[]
+  details: TOptionDetail[]
 }
 
-const OptionDetail: React.FC<Props> = ({ detail }) => {
-  const [selectedOption, setSelectedOption] = useState(detail[0])
+const OptionDetail: React.FC<Props> = ({ details }) => {
+  const [selectedOption, setSelectedOption] = useState(details[0])
   const handleSeletedDetail = (option: TOptionDetail) => {
     setSelectedOption(option)
   }
 
   return (
     <>
-      {detail.map((option) => (
+      {details.map((option) => (
         <OptionWrapper onClick={() => handleSeletedDetail(option)}>
           <Div>
             {selectedOption.id === option.id ? (

--- a/packages/client/src/components/templates/footer/index.tsx
+++ b/packages/client/src/components/templates/footer/index.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled'
+import { useCarts } from 'contexts/CartProvider'
+import { theme } from '../../../utils/styles'
+
+const Footer = () => {
+  const { carts } = useCarts()
+
+  return (
+    <>
+      {carts.length !== 0 ? (
+        <FooterWrapper>
+          {carts.map((cart: any) => (
+            <div key={`cart${cart.count}`}>{cart.name}</div>
+          ))}
+        </FooterWrapper>
+      ) : null}
+    </>
+  )
+}
+
+const FooterWrapper = styled.div`
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  height: 100px;
+  width: 1080px;
+  /* background-color: ${theme.LINE}; */
+`
+
+export default Footer

--- a/packages/client/src/components/templates/main/index.tsx
+++ b/packages/client/src/components/templates/main/index.tsx
@@ -1,13 +1,11 @@
 import { TMenu } from 'utils/types'
 import React, { useCallback, useMemo, useState } from 'react'
-import TabItem from '../../organisms/Card'
+import Card from '../../organisms/Card'
 import styled from '@emotion/styled'
 import Modal from 'components/atoms/Modal'
 import MenuOption from 'components/molecules/MenuOption'
-import Button from 'components/atoms/Button'
-import IconPlus from '../../../utils/images/plus.svg'
-import IconMinus from '../../../utils/images/minus.svg'
-import { theme } from '../../../utils/styles'
+import { getMenuAPI } from '../../../apis/kiosk'
+import Spinner from 'components/atoms/Spinner'
 
 interface Props {
   menus: TMenu[]
@@ -16,147 +14,66 @@ interface Props {
 const Page: React.FC<Props> = ({ menus }) => {
   const [selectedMenu, setSelectedMenu] = useState<TMenu | undefined>()
   const [visible, setVisible] = useState(false)
-  const [count, setCount] = useState(1)
 
-  // 옵션 클릭 시 해당 정보 객체로 받아오는 로직
-  // 나중에 구현 예정
-  //   const [selectedOption, setSelectedOption] = useState<any>()
-  //   const handleSelectedOption = (option: TOptionDetail) => {
-  // const selectedOptionFilter = selectedOption?.filter(
-  //   ({ id }: { id: number }) => option.id !== id,
-  // )
-  // const newSelectedOption = [...selectedOptionFilter, option]
-  // setSelectedOption(option)
-  //   }
+  const getMenu = async (id: number) => {
+    const data = await getMenuAPI(id)
+    setSelectedMenu(data)
+    setVisible(true)
+  }
 
-  const onClickMenu = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const { id } = (e.currentTarget as HTMLElement).dataset
-      const menu = menus.find((item) => item.id === Number(id))
-      setSelectedMenu(menu)
-      setVisible(true)
-    },
-    [menus],
-  )
-
-  const onIncreaseCount = useCallback(() => {
-    if (count >= 10) return
-
-    setCount((count) => count + 1)
-  }, [count])
-
-  const onDecreaseCount = useCallback(() => {
-    if (count <= 1) return
-
-    setCount((count) => count - 1)
-  }, [count])
-
-  const totalPrice = useMemo(() => {
-    return selectedMenu?.price ? selectedMenu.price * count : 0
-  }, [selectedMenu, count])
+  const onClickMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const { id } = (e.currentTarget as HTMLElement).dataset
+    getMenu(Number(id))
+  }, [])
 
   const handleInit = () => {
-    setVisible(false)
-    setCount(1)
     setSelectedMenu(undefined)
+    setVisible(false)
   }
 
   return (
     <>
-      <TabItemWrapper>
+      <CardWrapper>
         {menus?.map((menu, index) => (
-          <TabItem
+          <Card
             key={menu.id}
             menu={menu}
             onClickMenu={onClickMenu}
-            rank={index}></TabItem>
+            rank={index}></Card>
         ))}
-      </TabItemWrapper>
+      </CardWrapper>
 
       <Modal visible={visible} onClose={handleInit}>
-        <MenuModalWrapper>
-          <MenuInfoWrapper>
-            {selectedMenu ? (
-              <>
-                <TabItem
-                  key={selectedMenu.id}
-                  menu={selectedMenu}
-                  onClickMenu={onClickMenu}
-                />
-                <MenuOption options={selectedMenu.options} />
-              </>
-            ) : null}
-          </MenuInfoWrapper>
-
-          <CheckBox>
-            <Span>수량</Span>
-
-            <Button
-              onClick={onIncreaseCount}
-              style={{
-                width: '80px',
-                height: '50px',
-              }}>
-              <img src={IconPlus} />
-            </Button>
-            <Span>{count < 10 ? count : '최대 10'} 개</Span>
-            <Button
-              onClick={onDecreaseCount}
-              style={{
-                width: '80px',
-                height: '50px',
-                backgroundColor: `${theme.ERROR}`,
-              }}>
-              <img src={IconMinus} />
-            </Button>
-          </CheckBox>
-        </MenuModalWrapper>
-
-        <ButtonWrapper>
-          <Button onClick={handleInit} style={{ width: '300px' }}>
-            {totalPrice.toLocaleString()}원 담기
-          </Button>
-        </ButtonWrapper>
+        <MenuInfoWrapper>
+          {selectedMenu ? (
+            <>
+              <Card
+                key={selectedMenu.id}
+                menu={selectedMenu}
+                onClickMenu={onClickMenu}
+              />
+              <MenuOption
+                options={selectedMenu.options}
+                menuPrice={selectedMenu.price}
+              />
+            </>
+          ) : (
+            <Spinner></Spinner>
+          )}
+        </MenuInfoWrapper>
       </Modal>
     </>
   )
 }
 
-const MenuModalWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-`
-
 const MenuInfoWrapper = styled.div`
   display: flex;
 `
 
-const TabItemWrapper = styled.div`
+const CardWrapper = styled.div`
   display: flex;
   justify-items: flex-start;
   flex-wrap: wrap;
-`
-
-const Span = styled.span`
-  font-size: 30px;
-  width: 150px;
-  text-align: center;
-`
-
-const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-top: 100px;
-`
-
-const CheckBox = styled.div`
-  margin-top: 30px;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  margin: 20px;
-
-  align-items: center;
 `
 
 export default Page

--- a/packages/client/src/components/templates/main/index.tsx
+++ b/packages/client/src/components/templates/main/index.tsx
@@ -1,4 +1,4 @@
-import { TMenu } from 'utils/types'
+import { TMenu, TOptionDetail } from 'utils/types'
 import React, { useCallback, useMemo, useState } from 'react'
 import Card from '../../organisms/Card'
 import styled from '@emotion/styled'
@@ -6,6 +6,12 @@ import Modal from 'components/atoms/Modal'
 import MenuOption from 'components/molecules/MenuOption'
 import { getMenuAPI } from '../../../apis/kiosk'
 import Spinner from 'components/atoms/Spinner'
+import { useCarts } from 'contexts/CartProvider'
+
+// interface Cart {
+//   count: number
+//   selectedOption: TOptionDetail
+// }
 
 interface Props {
   menus: TMenu[]
@@ -14,6 +20,7 @@ interface Props {
 const Page: React.FC<Props> = ({ menus }) => {
   const [selectedMenu, setSelectedMenu] = useState<TMenu | undefined>()
   const [visible, setVisible] = useState(false)
+  const { addCart } = useCarts()
 
   const getMenu = async (id: number) => {
     const data = await getMenuAPI(id)
@@ -26,7 +33,11 @@ const Page: React.FC<Props> = ({ menus }) => {
     getMenu(Number(id))
   }, [])
 
-  const handleInit = () => {
+  const handleInit = (data?: any) => {
+    if (data) {
+      const { count, selectedOption } = data
+      addCart({ count, selectedOption, ...selectedMenu })
+    }
     setSelectedMenu(undefined)
     setVisible(false)
   }
@@ -55,6 +66,7 @@ const Page: React.FC<Props> = ({ menus }) => {
               <MenuOption
                 options={selectedMenu.options}
                 menuPrice={selectedMenu.price}
+                onClose={handleInit}
               />
             </>
           ) : (
@@ -68,6 +80,13 @@ const Page: React.FC<Props> = ({ menus }) => {
 
 const MenuInfoWrapper = styled.div`
   display: flex;
+  align-items: center;
+  justify-content: center;
+  & > * {
+    justify-content: flex-start;
+    align-self: flex-start;
+  }
+  margin-top: 100px;
 `
 
 const CardWrapper = styled.div`

--- a/packages/client/src/contexts/CartProvider.tsx
+++ b/packages/client/src/contexts/CartProvider.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from 'react'
+
+const CartContext = createContext<any>({})
+export const useCarts = () => useContext(CartContext)
+
+const CartProvider = ({ children }: { children: React.ReactNode }) => {
+  const [carts, setCarts] = useState<any>([])
+
+  const addCart = (newCart: any) => {
+    setCarts([
+      ...carts,
+      {
+        ...newCart,
+      },
+    ])
+  }
+
+  const initCart = () => {
+    setCarts([])
+  }
+
+  return (
+    <CartContext.Provider value={{ carts, addCart, initCart }}>
+      {children}
+    </CartContext.Provider>
+  )
+}
+
+export default CartProvider

--- a/packages/client/src/utils/types/index.ts
+++ b/packages/client/src/utils/types/index.ts
@@ -8,7 +8,7 @@ interface TOptionDetail extends TBase {
 }
 
 interface TMenuOption extends TBase {
-  detail: TOptionDetail[]
+  details: TOptionDetail[]
 }
 
 interface TMenu extends TBase {

--- a/packages/server/src/init/categoriesData.json
+++ b/packages/server/src/init/categoriesData.json
@@ -21,59 +21,59 @@
       },
       {
         "id": 3,
-        "name": "임팩트 웨이 프로틴",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/10530943-1224889444460882.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/10530943-4134889444511789.jpg",
-        "price": 20000,
+        "name": "식물성 프로틴 블렌드",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/11776868-2774835585006253.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/11776868-1414835585030163.jpg",
+        "price": 24000,
         "sellCount": 1
       },
       {
         "id": 4,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
+        "name": "클리어 비건 프로틴",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12360400-9224793048981991.png",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12360400-3624954986177342.jpg",
+        "price": 35900,
         "sellCount": 3
       },
       {
         "id": 5,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "더 다이어트",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/11350864-1624955021830545.jpg",
+        "imgUrl2": "",
+        "price": 75000,
+        "sellCount": 1
       },
       {
         "id": 6,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
+        "name": "소이+콜라겐 프로틴",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12785306-3884925756903499.jpg",
+        "imgUrl2": "",
+        "price": 42000,
         "sellCount": 0
       },
       {
         "id": 7,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "느린 흡수 카제인",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp/productimg/1600/1600/10798909-1134620653203269.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp/productimg/1600/1600/10798909-1134620653203269.jpg",
+        "price": 15000,
+        "sellCount": 1
       },
       {
         "id": 8,
-        "name": "클리어 웨이 아이솔레이트",
+        "name": "클리어 웨이 아이솔레이트2",
         "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
         "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
         "price": 35000,
-        "sellCount": 0
+        "sellCount": 2
       },
       {
         "id": 9,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "임팩트 웨이 프로틴2",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/10530943-1224889444460882.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/10530943-4134889444511789.jpg",
+        "price": 20000,
+        "sellCount": 1
       }
     ]
   },
@@ -83,43 +83,43 @@
     "menu": [
       {
         "id": 10,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "프로틴 팝콘",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12949471-2084945711818471.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12949471-3464945711864482.jpg",
+        "price": 15900,
+        "sellCount": 4
       },
       {
         "id": 11,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "비건 프로틴 크리스프스",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12521558-6704847725307043.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12521558-1994847725364187.jpg",
+        "price": 15900,
+        "sellCount": 2
       },
       {
         "id": 12,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "프로틴 브라우니",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/11094927-5614824894291165.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/11094927-1204923917672868.jpg",
+        "price": 32000,
+        "sellCount": 3
       },
       {
         "id": 13,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "100%인스턴스 오트",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/original/10529296-1104924200043050.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/10529296-1294924200063180.jpg",
+        "price": 27000,
+        "sellCount": 1
       },
       {
         "id": 14,
-        "name": "클리어 웨이 아이솔레이트",
-        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12457913-3554790136840897.jpg",
-        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12081395-1194954986226116.jpg",
-        "price": 35000,
-        "sellCount": 0
+        "name": "6레이어 프로틴바",
+        "imgUrl1": "https://static.thcdn.com/images/xsmall/webp//productimg/1600/1600/12116521-1674722549069642.jpg",
+        "imgUrl2": "https://static.thcdn.com/images/xsmall/webp//productimg/original/12116519-4874923891295347.jpg",
+        "price": 39000,
+        "sellCount": 2
       }
     ]
   },

--- a/packages/server/src/menus/menus.service.ts
+++ b/packages/server/src/menus/menus.service.ts
@@ -16,6 +16,7 @@ export class MenusService {
         .leftJoinAndSelect('menu.options', 'options')
         .leftJoinAndSelect('options.details', 'details')
         .where('menu.id = :id', { id })
+        .orderBy('details.id')
         .getOne()
 
       if (!menuInfo)

--- a/packages/server/src/options/entities/option.entity.ts
+++ b/packages/server/src/options/entities/option.entity.ts
@@ -3,7 +3,6 @@ import { OptionDetail } from './optionDetail.entity'
 import { CommonEntity } from '@common/CommonEntity'
 
 @Entity({ name: 'option_table' })
-@Unique(['name'])
 export class Option extends CommonEntity {
   @Column({ type: 'varchar', length: 30 })
   name!: string


### PR DESCRIPTION
# 💬 세부사항

장바구니 ContextAPI 정의 (기능은 미개발 다른 브랜치에서 작업 예정)
메뉴 요청 API 백엔드 연동
메뉴, 옵션 총액 계산

## 📎 관련 이슈

close #30 

## 😭 어려웠던 점 or 참고 사항

메뉴, 옵션 총액 계산을 위해 컴포넌트를 분리하고, 리팩토링하고
중복된 옵션 체크 시, 상태 변경을 막기 위한 계산 로직에서 조금 시간이 걸렸습니다.


## 🖼 스크린샷

<img width="754" alt="스크린샷 2022-08-11 오후 1 44 23" src="https://user-images.githubusercontent.com/52727782/184066107-10d0b74c-5d43-45cd-8a92-6d67a27b7fff.png">


## ⏰ 실제 소요 시간

4시간