### PR TITLE
feat : 장바구니 데이터 수정 시, 타이머 재작동

### DIFF
--- a/packages/client/src/components/templates/footer/Timer.tsx
+++ b/packages/client/src/components/templates/footer/Timer.tsx
@@ -1,7 +1,9 @@
+import { useCarts } from 'contexts/CartProvider'
 import { useEffect, useState } from 'react'
 
 const Timer = ({ initCart }: any) => {
-  const [seconds, setSeconds] = useState(20)
+  const [seconds, setSeconds] = useState(10)
+  const { carts } = useCarts()
 
   useEffect(() => {
     const countdown = setInterval(() => {
@@ -16,8 +18,12 @@ const Timer = ({ initCart }: any) => {
     return () => clearInterval(countdown)
   }, [seconds, initCart])
 
+  useEffect(() => {
+    setSeconds(10)
+  }, [carts])
+
   return (
-    <div onClick={() => setSeconds(20)}>
+    <div onClick={() => setSeconds(10)}>
       <div>시간 연장버튼</div>
       <div> {seconds < 10 ? `0${seconds}` : seconds} </div>
     </div>


### PR DESCRIPTION
# 💬 세부사항

장바구니 데이터 수정 시, 타이머 시간 재 정의

## 📎 관련 이슈

close #40 

## ⏰ 실제 소요 시간

5분
